### PR TITLE
`Kernel Source` scaffold

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,6 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'omniauth-github', '~> 2.0.0'
 # Omniauth rails csrf protection gem
 gem 'omniauth-rails_csrf_protection'
+
+# Rexml
+gem 'rexml'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (2.1.1)
+    rexml (3.2.5)
     ruby2_keywords (0.0.4)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
@@ -242,6 +243,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3, >= 6.1.3.2)
+  rexml
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/assets/stylesheets/kernel_sources.scss
+++ b/app/assets/stylesheets/kernel_sources.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the KernelSources controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/kernel_sources_controller.rb
+++ b/app/controllers/kernel_sources_controller.rb
@@ -1,0 +1,69 @@
+class KernelSourcesController < ApplicationController
+  before_action :set_kernel_source, only: %i[ show edit update destroy ]
+
+  # GET /kernel_sources or /kernel_sources.json
+  def index
+    @kernel_sources = KernelSource.all
+  end
+
+  # GET /kernel_sources/1 or /kernel_sources/1.json
+  def show
+  end
+
+  # GET /kernel_sources/new
+  def new
+    @kernel_source = KernelSource.new
+  end
+
+  # GET /kernel_sources/1/edit
+  def edit
+  end
+
+  # POST /kernel_sources or /kernel_sources.json
+  def create
+    @kernel_source = KernelSource.new(kernel_source_params)
+
+    respond_to do |format|
+      if @kernel_source.save
+        format.html { redirect_to @kernel_source, notice: "Kernel source was successfully created." }
+        format.json { render :show, status: :created, location: @kernel_source }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @kernel_source.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /kernel_sources/1 or /kernel_sources/1.json
+  def update
+    respond_to do |format|
+      if @kernel_source.update(kernel_source_params)
+        format.html { redirect_to @kernel_source, notice: "Kernel source was successfully updated." }
+        format.json { render :show, status: :ok, location: @kernel_source }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @kernel_source.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /kernel_sources/1 or /kernel_sources/1.json
+  def destroy
+    @kernel_source.destroy
+    respond_to do |format|
+      format.html { redirect_to kernel_sources_url, notice: "Kernel source was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_kernel_source
+      @kernel_source = KernelSource.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def kernel_source_params
+      params.require(:kernel_source).permit(:git_repo, :git_ref)
+    end
+end

--- a/app/helpers/kernel_sources_helper.rb
+++ b/app/helpers/kernel_sources_helper.rb
@@ -1,0 +1,2 @@
+module KernelSourcesHelper
+end

--- a/app/models/kernel_source.rb
+++ b/app/models/kernel_source.rb
@@ -1,0 +1,2 @@
+class KernelSource < ApplicationRecord
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -3,6 +3,7 @@
 <% if current_user %>
   <h3>Logged in as: <%= current_user.username %></h3>
   <%= button_to "Logout", logout_path, method: :get %>
+  <%= button_to "Create New Kernel", new_kernel_source_path, method: :get%>
 <% else %>
   <%= button_to "Login with GitHub", "/auth/github" %>
 <% end %>

--- a/app/views/kernel_sources/_form.html.erb
+++ b/app/views/kernel_sources/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: kernel_source) do |form| %>
+  <% if kernel_source.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(kernel_source.errors.count, "error") %> prohibited this kernel_source from being saved:</h2>
+
+      <ul>
+        <% kernel_source.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :git_repo %>
+    <%= form.text_field :git_repo %>
+  </div>
+
+  <div class="field">
+    <%= form.label :git_ref %>
+    <%= form.text_field :git_ref %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit value="Create Kernel" %>
+  </div>
+<% end %>

--- a/app/views/kernel_sources/_kernel_source.json.jbuilder
+++ b/app/views/kernel_sources/_kernel_source.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! kernel_source, :id, :git_repo, :git_ref, :created_at, :updated_at
+json.url kernel_source_url(kernel_source, format: :json)

--- a/app/views/kernel_sources/edit.html.erb
+++ b/app/views/kernel_sources/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Kernel Source</h1>
+
+<%= render 'form', kernel_source: @kernel_source %>
+
+<%= link_to 'Show', @kernel_source %> |
+<%= link_to 'Back', kernel_sources_path %>

--- a/app/views/kernel_sources/index.html.erb
+++ b/app/views/kernel_sources/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Kernel Sources</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Git repo</th>
+      <th>Git ref</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @kernel_sources.each do |kernel_source| %>
+      <tr>
+        <td><%= kernel_source.git_repo %></td>
+        <td><%= kernel_source.git_ref %></td>
+        <td><%= link_to 'Show', kernel_source %></td>
+        <td><%= link_to 'Edit', edit_kernel_source_path(kernel_source) %></td>
+        <td><%= link_to 'Destroy', kernel_source, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Kernel Source', new_kernel_source_path %>

--- a/app/views/kernel_sources/index.json.jbuilder
+++ b/app/views/kernel_sources/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @kernel_sources, partial: "kernel_sources/kernel_source", as: :kernel_source

--- a/app/views/kernel_sources/new.html.erb
+++ b/app/views/kernel_sources/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Kernel Source</h1>
+
+<%= render 'form', kernel_source: @kernel_source %>
+
+<%= link_to 'Back', kernel_sources_path %>

--- a/app/views/kernel_sources/show.html.erb
+++ b/app/views/kernel_sources/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Git repo:</strong>
+  <%= @kernel_source.git_repo %>
+</p>
+
+<p>
+  <strong>Git ref:</strong>
+  <%= @kernel_source.git_ref %>
+</p>
+
+<%= link_to 'Edit', edit_kernel_source_path(@kernel_source) %> |
+<%= link_to 'Back', kernel_sources_path %>

--- a/app/views/kernel_sources/show.json.jbuilder
+++ b/app/views/kernel_sources/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "kernel_sources/kernel_source", kernel_source: @kernel_source

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :kernel_sources
   resources :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 

--- a/db/migrate/20210912004617_create_kernel_sources.rb
+++ b/db/migrate/20210912004617_create_kernel_sources.rb
@@ -1,0 +1,10 @@
+class CreateKernelSources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :kernel_sources do |t|
+      t.string :git_repo
+      t.string :git_ref
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_11_003038) do
+ActiveRecord::Schema.define(version: 2021_09_12_004617) do
+
+  create_table "kernel_sources", force: :cascade do |t|
+    t.string "git_repo"
+    t.string "git_ref"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "provider"

--- a/test/controllers/kernel_sources_controller_test.rb
+++ b/test/controllers/kernel_sources_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class KernelSourcesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @kernel_source = kernel_sources(:one)
+  end
+
+  test "should get index" do
+    get kernel_sources_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_kernel_source_url
+    assert_response :success
+  end
+
+  test "should create kernel_source" do
+    assert_difference('KernelSource.count') do
+      post kernel_sources_url, params: { kernel_source: { git_ref: @kernel_source.git_ref, git_repo: @kernel_source.git_repo } }
+    end
+
+    assert_redirected_to kernel_source_url(KernelSource.last)
+  end
+
+  test "should show kernel_source" do
+    get kernel_source_url(@kernel_source)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_kernel_source_url(@kernel_source)
+    assert_response :success
+  end
+
+  test "should update kernel_source" do
+    patch kernel_source_url(@kernel_source), params: { kernel_source: { git_ref: @kernel_source.git_ref, git_repo: @kernel_source.git_repo } }
+    assert_redirected_to kernel_source_url(@kernel_source)
+  end
+
+  test "should destroy kernel_source" do
+    assert_difference('KernelSource.count', -1) do
+      delete kernel_source_url(@kernel_source)
+    end
+
+    assert_redirected_to kernel_sources_url
+  end
+end

--- a/test/fixtures/kernel_sources.yml
+++ b/test/fixtures/kernel_sources.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  git_repo: MyString
+  git_ref: MyString
+
+two:
+  git_repo: MyString
+  git_ref: MyString

--- a/test/models/kernel_source_test.rb
+++ b/test/models/kernel_source_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class KernelSourceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/kernel_sources_test.rb
+++ b/test/system/kernel_sources_test.rb
@@ -1,0 +1,45 @@
+require "application_system_test_case"
+
+class KernelSourcesTest < ApplicationSystemTestCase
+  setup do
+    @kernel_source = kernel_sources(:one)
+  end
+
+  test "visiting the index" do
+    visit kernel_sources_url
+    assert_selector "h1", text: "Kernel Sources"
+  end
+
+  test "creating a Kernel source" do
+    visit kernel_sources_url
+    click_on "New Kernel Source"
+
+    fill_in "Git ref", with: @kernel_source.git_ref
+    fill_in "Git repo", with: @kernel_source.git_repo
+    click_on "Create Kernel"
+
+    assert_text "Kernel source was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Kernel source" do
+    visit kernel_sources_url
+    click_on "Edit", match: :first
+
+    fill_in "Git ref", with: @kernel_source.git_ref
+    fill_in "Git repo", with: @kernel_source.git_repo
+    click_on "Update Kernel source"
+
+    assert_text "Kernel source was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Kernel source" do
+    visit kernel_sources_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Kernel source was successfully destroyed"
+  end
+end


### PR DESCRIPTION
### Create Kernel
- Genereate `KernelSource` scaffold:
    - git_repo:string
    - git_ref:string
 - form partial for new kerenel altered so submit button says, "Create Kernel" instead of "Create Kernel source."
 - Altered `kernel_source_test.rb` -> "creating a Kernel source" to reflect button value change
 - Rexml gem added so tests would pass
 
![Capture](https://user-images.githubusercontent.com/74803363/132967419-dc10dd86-cd86-4659-9d4d-c565b0e0d811.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/132967433-520d1d35-b150-4397-a162-4fc55d747752.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/132967435-b14f1c51-42de-46e1-95c4-e78c36664ad1.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/132967437-af3407ff-df2d-440a-a3c9-f70315d3ac4d.PNG)