### PR TITLE
Create kernel config model

### DIFF
--- a/app/assets/stylesheets/kernel_configs.scss
+++ b/app/assets/stylesheets/kernel_configs.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the KernelConfigs controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/kernel_configs_controller.rb
+++ b/app/controllers/kernel_configs_controller.rb
@@ -1,0 +1,69 @@
+class KernelConfigsController < ApplicationController
+  before_action :set_kernel_config, only: %i[ show edit update destroy ]
+
+  # GET /kernel_configs or /kernel_configs.json
+  def index
+    @kernel_configs = KernelConfig.all
+  end
+
+  # GET /kernel_configs/1 or /kernel_configs/1.json
+  def show
+  end
+
+  # GET /kernel_configs/new
+  def new
+    @kernel_config = KernelConfig.new
+  end
+
+  # GET /kernel_configs/1/edit
+  def edit
+  end
+
+  # POST /kernel_configs or /kernel_configs.json
+  def create
+    @kernel_config = KernelConfig.new(kernel_config_params)
+
+    respond_to do |format|
+      if @kernel_config.save
+        format.html { redirect_to @kernel_config, notice: "Kernel config was successfully created." }
+        format.json { render :show, status: :created, location: @kernel_config }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @kernel_config.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /kernel_configs/1 or /kernel_configs/1.json
+  def update
+    respond_to do |format|
+      if @kernel_config.update(kernel_config_params)
+        format.html { redirect_to @kernel_config, notice: "Kernel config was successfully updated." }
+        format.json { render :show, status: :ok, location: @kernel_config }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @kernel_config.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /kernel_configs/1 or /kernel_configs/1.json
+  def destroy
+    @kernel_config.destroy
+    respond_to do |format|
+      format.html { redirect_to kernel_configs_url, notice: "Kernel config was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_kernel_config
+      @kernel_config = KernelConfig.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def kernel_config_params
+      params.require(:kernel_config).permit(:user_id, :config_url)
+    end
+end

--- a/app/helpers/kernel_configs_helper.rb
+++ b/app/helpers/kernel_configs_helper.rb
@@ -1,0 +1,2 @@
+module KernelConfigsHelper
+end

--- a/app/models/kernel_config.rb
+++ b/app/models/kernel_config.rb
@@ -1,0 +1,4 @@
+class KernelConfig < ApplicationRecord
+  belongs_to: :user
+  has_one_attached: :config_url
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_one: :kernel_config
+  
   def self.create_with_omniauth(auth)
     create! do |user|
       user.provider = auth["provider"]

--- a/app/views/kernel_configs/_form.html.erb
+++ b/app/views/kernel_configs/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: kernel_config) do |form| %>
+  <% if kernel_config.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(kernel_config.errors.count, "error") %> prohibited this kernel_config from being saved:</h2>
+
+      <ul>
+        <% kernel_config.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :config_url %>
+    <%= form.file_field :config_url %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/kernel_configs/_kernel_config.json.jbuilder
+++ b/app/views/kernel_configs/_kernel_config.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! kernel_config, :id, :user_id, :created_at, :updated_at
+json.url kernel_config_url(kernel_config, format: :json)

--- a/app/views/kernel_configs/edit.html.erb
+++ b/app/views/kernel_configs/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Kernel Config</h1>
+
+<%= render 'form', kernel_config: @kernel_config %>
+
+<%= link_to 'Show', @kernel_config %> |
+<%= link_to 'Back', kernel_configs_path %>

--- a/app/views/kernel_configs/index.html.erb
+++ b/app/views/kernel_configs/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Kernel Configs</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>User</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @kernel_configs.each do |kernel_config| %>
+      <tr>
+        <td><%= kernel_config.user_id %></td>
+        <td><%= link_to 'Show', kernel_config %></td>
+        <td><%= link_to 'Edit', edit_kernel_config_path(kernel_config) %></td>
+        <td><%= link_to 'Destroy', kernel_config, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Kernel Config', new_kernel_config_path %>

--- a/app/views/kernel_configs/index.json.jbuilder
+++ b/app/views/kernel_configs/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @kernel_configs, partial: "kernel_configs/kernel_config", as: :kernel_config

--- a/app/views/kernel_configs/new.html.erb
+++ b/app/views/kernel_configs/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Kernel Config</h1>
+
+<%= render 'form', kernel_config: @kernel_config %>
+
+<%= link_to 'Back', kernel_configs_path %>

--- a/app/views/kernel_configs/show.html.erb
+++ b/app/views/kernel_configs/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>User:</strong>
+  <%= @kernel_config.user_id %>
+</p>
+
+<%= link_to 'Edit', edit_kernel_config_path(@kernel_config) %> |
+<%= link_to 'Back', kernel_configs_path %>

--- a/app/views/kernel_configs/show.json.jbuilder
+++ b/app/views/kernel_configs/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "kernel_configs/kernel_config", kernel_config: @kernel_config

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :kernel_configs
   resources :kernel_sources
   resources :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20210913194455_create_kernel_configs.rb
+++ b/db/migrate/20210913194455_create_kernel_configs.rb
@@ -1,0 +1,9 @@
+class CreateKernelConfigs < ActiveRecord::Migration[6.1]
+  def change
+    create_table :kernel_configs do |t|
+      t.integer :user_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_13_181833) do
+ActiveRecord::Schema.define(version: 2021_09_13_194455) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,12 @@ ActiveRecord::Schema.define(version: 2021_09_13_181833) do
     t.integer "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "kernel_configs", force: :cascade do |t|
+    t.integer "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "kernel_sources", force: :cascade do |t|

--- a/test/controllers/kernel_configs_controller_test.rb
+++ b/test/controllers/kernel_configs_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class KernelConfigsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @kernel_config = kernel_configs(:one)
+  end
+
+  test "should get index" do
+    get kernel_configs_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_kernel_config_url
+    assert_response :success
+  end
+
+  test "should create kernel_config" do
+    assert_difference('KernelConfig.count') do
+      post kernel_configs_url, params: { kernel_config: { user_id: @kernel_config.user_id } }
+    end
+
+    assert_redirected_to kernel_config_url(KernelConfig.last)
+  end
+
+  test "should show kernel_config" do
+    get kernel_config_url(@kernel_config)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_kernel_config_url(@kernel_config)
+    assert_response :success
+  end
+
+  test "should update kernel_config" do
+    patch kernel_config_url(@kernel_config), params: { kernel_config: { user_id: @kernel_config.user_id } }
+    assert_redirected_to kernel_config_url(@kernel_config)
+  end
+
+  test "should destroy kernel_config" do
+    assert_difference('KernelConfig.count', -1) do
+      delete kernel_config_url(@kernel_config)
+    end
+
+    assert_redirected_to kernel_configs_url
+  end
+end

--- a/test/fixtures/kernel_configs.yml
+++ b/test/fixtures/kernel_configs.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+
+two:
+  user_id: 1

--- a/test/models/kernel_config_test.rb
+++ b/test/models/kernel_config_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class KernelConfigTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/kernel_configs_test.rb
+++ b/test/system/kernel_configs_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class KernelConfigsTest < ApplicationSystemTestCase
+  setup do
+    @kernel_config = kernel_configs(:one)
+  end
+
+  test "visiting the index" do
+    visit kernel_configs_url
+    assert_selector "h1", text: "Kernel Configs"
+  end
+
+  test "creating a Kernel config" do
+    visit kernel_configs_url
+    click_on "New Kernel Config"
+
+    fill_in "User", with: @kernel_config.user_id
+    click_on "Create Kernel config"
+
+    assert_text "Kernel config was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Kernel config" do
+    visit kernel_configs_url
+    click_on "Edit", match: :first
+
+    fill_in "User", with: @kernel_config.user_id
+    click_on "Update Kernel config"
+
+    assert_text "Kernel config was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Kernel config" do
+    visit kernel_configs_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Kernel config was successfully destroyed"
+  end
+end


### PR DESCRIPTION
### Setup `KernelConfig` model and associations:
- Generated `KernelConfig` scaffold (model) that has `user_id` column for association with `:user`
- Added `has_one`: `kernel_config` association in `user.rb` - A user will have one `kernel_config` since only one `.config file` will be uploaded/overridden  at a time.
- Added `has_one_attached` association to `kernel_config.rb` for the one `.config_file` that will be uploaded in a form.
- Added `belongs_to`: `:user` association to `kernel_config.rb`
- Added `:config_url` to the list of permitted params in `kernel_config_controller.rb`