### PR TITLE
How and show fields for kernel build

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,3 +11,29 @@ import "channels"
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
+
+window.addEventListener("load", () => {
+  const newConfigButton = document.getElementById("show_new_config_form");
+  const newSourceButton = document.getElementById("show_new_source_form");
+  const sourceForm = document.getElementById("kernel_source_form");
+  const configForm = document.getElementById("kernel_config_form");
+
+  sourceForm.style.display = "none";
+  configForm.style.display = "none";
+
+  newConfigButton.addEventListener("click", (e) => {
+    if( configForm.style.display == "none"){
+      configForm.style.display = "block";
+    } else {
+      configForm.style.display = "none";
+    }
+  });
+
+  newSourceButton.addEventListener("click", (e) => {
+    if( sourceForm.style.display == "none"){
+      sourceForm.style.display = "block";
+    } else {
+      sourceForm.style.display = "none";
+    }
+  });
+});

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,28 +12,18 @@ Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
+const toggleFormVisibility = (form, target) => {
+  form.style.display = "none";
+  target.addEventListener("click", (e) => {
+    if( form.style.display == "none" ){
+      form.style.display = "block";
+    } else {
+      form.style.display = "none";
+    }
+  });
+}
+
 window.addEventListener("load", () => {
-  const newConfigButton = document.getElementById("show_new_config_form");
-  const newSourceButton = document.getElementById("show_new_source_form");
-  const sourceForm = document.getElementById("kernel_source_form");
-  const configForm = document.getElementById("kernel_config_form");
-
-  sourceForm.style.display = "none";
-  configForm.style.display = "none";
-
-  newConfigButton.addEventListener("click", (e) => {
-    if( configForm.style.display == "none"){
-      configForm.style.display = "block";
-    } else {
-      configForm.style.display = "none";
-    }
-  });
-
-  newSourceButton.addEventListener("click", (e) => {
-    if( sourceForm.style.display == "none"){
-      sourceForm.style.display = "block";
-    } else {
-      sourceForm.style.display = "none";
-    }
-  });
+  toggleFormVisibility(document.getElementById("kernel_config_form"), document.getElementById("show_new_config_form"));
+  toggleFormVisibility(document.getElementById("kernel_source_form"), document.getElementById("show_new_source_form"));
 });

--- a/app/views/kernel_builds/_form.html.erb
+++ b/app/views/kernel_builds/_form.html.erb
@@ -14,7 +14,7 @@
   <div class="field">
     <%= form.label :config_url %>
     <%= form.collection_select :kernel_config, @current_user_kernel_configs, :id, :config_url, prompt: "-- Select config file --" %>
-    <%= button_tag "Upload New Kerenel Config", type: "button", id: "show_new_config_form" %>
+    <%= button_tag "Upload New Kernel Config", type: "button", id: "show_new_config_form" %>
   </div>
 
   <div class="field" id="kernel_config_form">

--- a/app/views/kernel_builds/_form.html.erb
+++ b/app/views/kernel_builds/_form.html.erb
@@ -14,6 +14,7 @@
   <div class="field">
     <%= form.label :config_url %>
     <%= form.collection_select :kernel_config, @current_user_kernel_configs, :id, :config_url, prompt: "-- Select config file --" %>
+    <%= button_tag "Upload New Kerenel Config", type: "button", id: "show_new_config_form" %>
   </div>
 
   <div class="field" id="kernel_config_form">
@@ -29,6 +30,7 @@
   <div class="field">
     <%= form.label :git_ref %>
     <%= form.collection_select :kernel_source, @current_user_kernel_sources, :id, :git_ref, prompt: "-- Select Git Ref --" %>
+    <%= button_tag "Create New Kernel Source", type: "button", id: "show_new_source_form" %>
   </div>
 
   <div id="kernel_source_form">

--- a/app/views/kernel_builds/index.html.erb
+++ b/app/views/kernel_builds/index.html.erb
@@ -28,4 +28,4 @@
 
 <br>
 
-<%= link_to 'New Kernel Build', new_kernel_build_path %>
+<%= button_to 'New Kernel Build', new_kernel_build_path, method: :get %>


### PR DESCRIPTION
### Show/Hide new `kernel_source`/`kernel_config` form sections
- Add JS to add event listeners to:
  - The window (for loading)
  - The button to toggle the new source form visible
  - The button to toggle the new config form visible
  - Both buttons check the `style.display` value and set accordingly from "block" to "none" and vice versa
- Add two buttons to the form partial for a new `kernel_build` for:
  - Viewing the new `kernel_config` form
  - Viewing the new `kernel_source` form
- Changed a `link_to` to a `button_to` for proper page loading (unknown why this fixes the issue* currently)

![Capture](https://user-images.githubusercontent.com/74803363/133866998-7f33f47a-e072-4c55-8402-c2e754cc9607.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/133867018-c8fb94dc-6b7d-4c3c-b04d-b06127fbdb7a.PNG)

*There was an issue with linking to the form partial for a new `kernel_build` from `kernel_build#index` using a `link_to` caused the page to not call `application.js` before loading.
