### PR TITLE
Toggle new form vs existing

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -12,18 +12,43 @@ Rails.start()
 Turbolinks.start()
 ActiveStorage.start()
 
-const toggleFormVisibility = (form, target) => {
+const toggleFormVisibility = (dropdownParam, formParam, dropdownButtonParam, formButtonParam) => {
+  const dropdown = dropdownParam;
+  const form = formParam;
+  const dropdownButton = dropdownButtonParam;
+  const formButton = formButtonParam;
+  
+  dropdown.style.display = "block";
   form.style.display = "none";
-  target.addEventListener("click", (e) => {
-    if( form.style.display == "none" ){
-      form.style.display = "block";
-    } else {
-      form.style.display = "none";
-    }
+  formButton.style.display = "block";
+  dropdownButton.style.display = "none";
+
+  dropdownButton.addEventListener("click", (e) => {
+    formButton.style.display = "block";
+    dropdown.style.display = "block";
+    form.style.display = "none";
+    dropdownButton.style.display = "none";
+  });
+
+  formButton.addEventListener("click", (e) => {
+    dropdownButton.style.display = "block";
+    form.style.display = "block";
+    dropdown.style.display = "none";
+    formButton.style.display = "none";
   });
 }
 
 window.addEventListener("load", () => {
-  toggleFormVisibility(document.getElementById("kernel_config_form"), document.getElementById("show_new_config_form"));
-  toggleFormVisibility(document.getElementById("kernel_source_form"), document.getElementById("show_new_source_form"));
+  toggleFormVisibility(
+    document.getElementById("config_dropdown_form"),
+    document.getElementById("kernel_config_form"),
+    document.getElementById("show_config_dropdown"),
+    document.getElementById("show_new_config_form")
+  );
+  toggleFormVisibility(
+    document.getElementById("source_dropdown_forms"),
+    document.getElementById("kernel_source_form"),
+    document.getElementById("show_source_dropdown"),
+    document.getElementById("show_new_source_form")
+  );
 });

--- a/app/views/kernel_builds/_form.html.erb
+++ b/app/views/kernel_builds/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: kernel_build) do |form| %>
   <% if kernel_build.errors.any? %>
     <div id="error_explanation">
-      <h2><%= pluralize(kernel_build.errors.count, "error") %> prohibited this kernel_build from being saved:</h2>
+      <h2>ERROR: <%= pluralize(kernel_build.errors.count, "error") %></h2>
 
       <ul>
         <% kernel_build.errors.each do |error| %>
@@ -11,26 +11,49 @@
     </div>
   <% end %>
 
-  <div class="field">
+
+  <div class="field", id="config_dropdown_form">
     <%= form.label :config_url %>
-    <%= form.collection_select :kernel_config, @current_user_kernel_configs, :id, :config_url, prompt: "-- Select config file --" %>
-    <%= button_tag "Upload New Kernel Config", type: "button", id: "show_new_config_form" %>
+    <%= collection_select :kernel_config,
+      :kernel_url,
+      @current_user_kernel_configs,
+      :id,
+      :config_url,
+      prompt: "-- Select config file --"
+    %>
+    <%= button_tag "Upload New Kernel Config",type: "button", id: "show_new_config_form" %>
   </div>
 
   <div class="field" id="kernel_config_form">
     <%= form.label :config_url %>
     <%= form.file_field :config_url %>
+    <%= button_tag "Select Existing Kernel Config",type: "button", id: "show_config_dropdown" %>
   </div>
 
-  <div class="field">
-    <%= form.label :git_repo %>
-    <%= form.collection_select :kernel_source, @current_user_kernel_sources, :id, :git_repo, prompt: "-- Select Git Repo --" %>
-  </div>
 
-  <div class="field">
-    <%= form.label :git_ref %>
-    <%= form.collection_select :kernel_source, @current_user_kernel_sources, :id, :git_ref, prompt: "-- Select Git Ref --" %>
-    <%= button_tag "Create New Kernel Source", type: "button", id: "show_new_source_form" %>
+  <div id="source_dropdown_forms">
+    <div class="field", id="git_repo_dropdown_form" >
+      <%= form.label :git_repo %>
+      <%= collection_select :kernel_source,
+        :git_repo,
+        @current_user_kernel_sources,
+        :id,
+        :git_repo,
+        prompt: "-- Select Git Repo --"
+      %>
+    </div>
+
+    <div class="field", id="git_ref_dropdown_form" >
+      <%= form.label :git_ref %>
+      <%= collection_select :kernel_source,
+        :git_ref,
+        @current_user_kernel_sources,
+        :id,
+        :git_ref,
+        prompt: "-- Select Git Ref --"
+      %>
+      <%= button_tag "Create New Kernel Source", type: "button", id: "show_new_source_form" %>
+    </div>
   </div>
 
   <div id="kernel_source_form">
@@ -43,6 +66,7 @@
       <%= form.label :git_ref %>
       <%= form.text_field :git_ref %>
     </div>
+    <%= button_tag "Select Existing Kernel Source",type: "button", id: "show_source_dropdown" %>
   </div>
 
   <div class="actions">


### PR DESCRIPTION
### Change how kernel build forms are shown/hidden
- Add two new buttons to form partial for `kernel_build`:
  - Add a new button to show dropdown for existing kernel configs
  - Add a new button to show dropdown section for existing kernel sources (git_repos and git_refs)
- Added `id`'s for sections that didn't have any to toggle them to be visible or not
- In `application.js` refactor how `toggleFormVisibility` functions:
  - now when a user clicks the corresponding `new config/source` or `select existing config/source` the respective form appears and the opposite is hidden.

![Capture](https://user-images.githubusercontent.com/74803363/134243582-069993ad-9130-47b0-96ca-4272fd7ba503.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/134243624-a658f0cf-7256-44b3-a738-fefca40faf0f.PNG)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/74803363/134244508-e1b9fd1f-bfec-4247-b28d-b9150761d8b8.gif)
