### PR TITLE
Initial design changes with bootstrap

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -1,0 +1,5 @@
+.top-right-corner {
+  position: fixed; /* or position: absolute; */
+  top: 0;
+  right: 0;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,7 @@
 class HomeController < ApplicationController
   def index
-    
+    if current_user
+      @kernel_builds = current_user.kernel_builds.all
+    end
   end
 end

--- a/app/controllers/kernel_builds_controller.rb
+++ b/app/controllers/kernel_builds_controller.rb
@@ -20,6 +20,7 @@ class KernelBuildsController < ApplicationController
 
   # GET /kernel_builds/1/edit
   def edit
+    @kernel_build = KernelBuild.find(params[:id])
   end
 
   # POST /kernel_builds or /kernel_builds.json
@@ -39,7 +40,6 @@ class KernelBuildsController < ApplicationController
       kernel_source = KernelSource.new(git_repo: git_repo, git_ref: git_ref, user: current_user)
     end
 
-    # @kernel_build = KernelBuild.new(kernel_build_params)
     @kernel_build = KernelBuild.new(
       user: current_user,
       kernel_config: kernel_config,
@@ -48,7 +48,7 @@ class KernelBuildsController < ApplicationController
 
     respond_to do |format|
       if @kernel_build.save
-        format.html { redirect_to @kernel_build, notice: "Kernel build was successfully created." }
+        format.html { redirect_to root_path, notice: "Kernel build was successfully created." }
         format.json { render :show, status: :created, location: @kernel_build }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -1,0 +1,5 @@
+module HomeHelper
+  def user_avatar(user)
+    image_tag("https://github.com/#{user.username}.png", width: 50, class: "border")
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,14 +1,9 @@
-<h1>WELCOME TO KERNEL BUILDER!</h1>
-
 <div class="container-fluid">
   <% if current_user %>
+    <%= render 'shared/logout_button' %>
 
-  <div class="top-right-corner dropdown">
-    <%= button_to "Lougout", logout_path, class: "btn btn-lg btn-secondary", method: :get %>
-  </div>
-
-
-  <%= button_to "Create New Kernel", new_kernel_build_path, method: :get, class: "btn btn-lg btn-primary"%>
+    <%= render 'shared/kernel_table' %>
+    <%= button_to "Create New Kernel", new_kernel_build_path, method: :get, class: "btn btn-lg btn-primary"%>
   <% else %>
     <div class="top-right-corner">
       <%= button_to "Login with GitHub", "/auth/github", class: "btn btn-lg btn-primary" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,17 @@
 <h1>WELCOME TO KERNEL BUILDER!</h1>
 
-<% if current_user %>
-  <h3>Logged in as: <%= current_user.username %></h3>
-  <%= button_to "Logout", logout_path, method: :get %>
-  <%= button_to "Create New Kernel", new_kernel_build_path, method: :get%>
-<% else %>
-  <%= button_to "Login with GitHub", "/auth/github" %>
-<% end %>
+<div class="container-fluid">
+  <% if current_user %>
+
+  <div class="top-right-corner dropdown">
+    <%= button_to "Lougout", logout_path, class: "btn btn-lg btn-secondary", method: :get %>
+  </div>
+
+
+  <%= button_to "Create New Kernel", new_kernel_build_path, method: :get, class: "btn btn-lg btn-primary"%>
+  <% else %>
+    <div class="top-right-corner">
+      <%= button_to "Login with GitHub", "/auth/github", class: "btn btn-lg btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/kernel_builds/_form.html.erb
+++ b/app/views/kernel_builds/_form.html.erb
@@ -12,7 +12,7 @@
   <% end %>
 
 
-  <div class="field", id="config_dropdown_form">
+  <div class="field mb-3", id="config_dropdown_form">
     <%= form.label :config_url %>
     <%= collection_select :kernel_config,
       :id,
@@ -21,13 +21,13 @@
       :config_filename,
       prompt: "-- Select config file --"
     %>
-    <%= button_tag "Upload New Kernel Config",type: "button", id: "show_new_config_form" %>
+    <%= button_tag "Upload New Kernel Config",type: "button", id: "show_new_config_form", class: "btn btn-secondary mt-2" %>
   </div>
 
-  <div class="field" id="kernel_config_form">
+  <div class="field mb-3" id="kernel_config_form">
     <%= form.label :config_url %>
     <%= form.file_field :config_url %>
-    <%= button_tag "Select Existing Kernel Config",type: "button", id: "show_config_dropdown" %>
+    <%= button_tag "Select Existing Kernel Config",type: "button", id: "show_config_dropdown", class: "btn btn-secondary" %>
   </div>
 
 
@@ -43,7 +43,7 @@
       %>
     </div>
 
-    <%= button_tag "Create New Kernel Source", type: "button", id: "show_new_source_form" %>
+    <%= button_tag "Create New Kernel Source", type: "button", id: "show_new_source_form", class: "btn btn-secondary" %>
   </div>
 
   <div id="kernel_source_form">
@@ -56,10 +56,10 @@
       <%= form.label :git_ref %>
       <%= form.text_field :git_ref %>
     </div>
-    <%= button_tag "Select Existing Kernel Source",type: "button", id: "show_source_dropdown" %>
+    <%= button_tag "Select Existing Kernel Source",type: "button", id: "show_source_dropdown", class: "btn btn-secondary" %>
   </div>
 
-  <div class="actions">
-    <%= form.submit %>
+  <div class="actions mt-4">
+    <%= form.submit "Create Kernel Build", class: "btn btn-lg btn-primary" %>
   </div>
 <% end %>

--- a/app/views/kernel_builds/edit.html.erb
+++ b/app/views/kernel_builds/edit.html.erb
@@ -1,6 +1,8 @@
-<h1>Editing Kernel Build</h1>
+<%= render 'shared/logout_button' %>
 
-<%= render 'form', kernel_build: @kernel_build %>
+<h3>Current Info:<h3>
+<%= render 'shared/kernel_info', kernel_build: @kernel_build %>
+<h2>Editing Kernel Build</h2>
+<%= render 'shared/edit_form', kernel_build: @kernel_build %>
 
-<%= link_to 'Show', @kernel_build %> |
-<%= link_to 'Back', kernel_builds_path %>
+<%= button_to 'Back', root_path, method: :get, class: "btn btn-secondary" %>

--- a/app/views/kernel_builds/index.html.erb
+++ b/app/views/kernel_builds/index.html.erb
@@ -1,31 +1,8 @@
-<p id="notice"><%= notice %></p>
-
-<h1>Kernel Builds</h1>
-
-<table>
-  <thead>
-    <tr>
-      <th>Kernel</th>
-      <th>Config</th>
-      <th>Artifact url</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @kernel_builds.each do |kernel_build| %>
-      <tr>
-        <td><%= kernel_build.kernel_source_id %></td>
-        <td><%= kernel_build.kernel_config_id %></td>
-        <td><%= kernel_build.artifact_url %></td>
-        <td><%= link_to 'Show', kernel_build %></td>
-        <td><%= link_to 'Edit', edit_kernel_build_path(kernel_build) %></td>
-        <td><%= link_to 'Destroy', kernel_build, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render 'shared/kernel_table', kernel_build: @kernel_build %>
 
 <br>
 
-<%= button_to 'New Kernel Build', new_kernel_build_path, method: :get %>
+<%= button_to 'New Kernel Build', new_kernel_build_path, method: :get, class: "btn btn-primary" %>
+<%= render 'shared/logout_button' %>
+
+<%= button_to 'Home', root_path, method: :get, class: "btn btn-secondary" %>

--- a/app/views/kernel_builds/new.html.erb
+++ b/app/views/kernel_builds/new.html.erb
@@ -1,5 +1,7 @@
-<h1>New Kernel Build</h1>
+<%= render 'shared/logout_button' %>
+
+<h2>New Kernel Build</h2>
 
 <%= render 'form', kernel_build: @kernel_build %>
 
-<%= link_to 'Back', root_path %>
+<%= button_to 'Back', root_path, method: :get, class: "btn btn-secondary" %>

--- a/app/views/kernel_builds/new.html.erb
+++ b/app/views/kernel_builds/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', kernel_build: @kernel_build %>
 
-<%= link_to 'Back', kernel_builds_path %>
+<%= link_to 'Back', root_path %>

--- a/app/views/kernel_builds/show.html.erb
+++ b/app/views/kernel_builds/show.html.erb
@@ -1,19 +1,6 @@
-<p id="notice"><%= notice %></p>
+<%= render 'shared/logout_button' %>
 
-<p>
-  <strong>Kernel:</strong>
-  <%= @kernel_build.kernel_source_id %>
-</p>
+<%= render 'shared/kernel_info', kernel_build: @kernel_build %>
 
-<p>
-  <strong>Config:</strong>
-  <%= @kernel_build.kernel_config_id %>
-</p>
-
-<p>
-  <strong>Artifact url:</strong>
-  <%= @kernel_build.artifact_url %>
-</p>
-
-<%= link_to 'Edit', edit_kernel_build_path(@kernel_build) %> |
-<%= link_to 'Back', kernel_builds_path %>
+<%= button_to 'Edit', edit_kernel_build_path(@kernel_build), method: :get, class: "btn btn-warning mb-2" %>
+<%= button_to 'Back', root_path, method: :get, class: "btn btn-secondary" %>

--- a/app/views/shared/_edit_form.html.erb
+++ b/app/views/shared/_edit_form.html.erb
@@ -1,0 +1,65 @@
+<%= form_with(model: kernel_build) do |form| %>
+  <% if kernel_build.errors.any? %>
+    <div id="error_explanation">
+      <h2>ERROR: <%= pluralize(kernel_build.errors.count, "error") %></h2>
+
+      <ul>
+        <% kernel_build.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+
+  <div class="field mb-3", id="config_dropdown_form">
+    <%= form.label :config_url %>
+    <%= collection_select :kernel_config,
+      :id,
+      @current_user_kernel_configs,
+      :id,
+      :config_filename,
+      prompt: "-- Select config file --"
+    %>
+    <%= button_tag "Upload New Kernel Config",type: "button", id: "show_new_config_form", class: "btn btn-secondary mt-2" %>
+  </div>
+
+  <div class="field mb-3" id="kernel_config_form">
+    <%= form.label :config_url %>
+    <%= form.file_field :config_url %>
+    <%= button_tag "Select Existing Kernel Config",type: "button", id: "show_config_dropdown", class: "btn btn-secondary" %>
+  </div>
+
+
+  <div id="source_dropdown_form">
+    <div class="field", id="source_dropdown_form" >
+      <%= form.label :kernel_source %>
+      <%= collection_select :kernel_source,
+        :id,
+        @current_user_kernel_sources,
+        :id,
+        :display_name,
+        prompt: "-- Select Kernel Source --"
+      %>
+    </div>
+
+    <%= button_tag "Create New Kernel Source", type: "button", id: "show_new_source_form", class: "btn btn-secondary" %>
+  </div>
+
+  <div id="kernel_source_form">
+    <div class="field">
+      <%= form.label :git_repo %>
+      <%= form.text_field :git_repo %>
+    </div>
+
+    <div class="field">
+      <%= form.label :git_ref %>
+      <%= form.text_field :git_ref %>
+    </div>
+    <%= button_tag "Select Existing Kernel Source",type: "button", id: "show_source_dropdown", class: "btn btn-secondary" %>
+  </div>
+
+  <div class="actions mt-4">
+    <%= form.submit "Create Kernel Build", class: "btn btn-lg btn-primary" %>
+  </div>
+<% end %>

--- a/app/views/shared/_kernel_info.html.erb
+++ b/app/views/shared/_kernel_info.html.erb
@@ -1,0 +1,16 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Kernel Config File:</strong>
+  <%= @kernel_build.kernel_config.config_filename %>
+</p>
+
+<p>
+  <strong>Kernel Source Info:</strong>
+  <%= @kernel_build.kernel_source.display_name %>
+</p>
+
+<p>
+  <strong>Artifact url:</strong>
+  <%= @kernel_build.artifact_url %>
+</p>

--- a/app/views/shared/_kernel_table.html.erb
+++ b/app/views/shared/_kernel_table.html.erb
@@ -1,0 +1,26 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Kernel Builds</h1>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Kernel Config</th>
+      <th scope="col">Kernel Source</th>
+      <th scope="col">Artifact url</th>
+      <th  scope="col" colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @kernel_builds.each do |kernel_build| %>
+      <tr>
+        <td scope="row"><%= kernel_build.kernel_config.config_filename %></td>
+        <td><%= kernel_build.kernel_source.display_name %></td>
+        <td><%= kernel_build.artifact_url %></td>
+        <td><%= button_to 'Edit', edit_kernel_build_path(kernel_build), method: :get, class: "btn btn-sm btn-warning" %></td>
+        <td><%= button_to 'Destroy', kernel_build, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-sm btn-danger" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_logout_button.html.erb
+++ b/app/views/shared/_logout_button.html.erb
@@ -1,0 +1,3 @@
+<div class="top-right-corner dropdown">
+  <%= button_to "Lougout", logout_path, class: "btn btn-lg btn-secondary", method: :get %>
+</div>

--- a/app/views/shared/_logout_button.html.erb
+++ b/app/views/shared/_logout_button.html.erb
@@ -1,3 +1,3 @@
 <div class="top-right-corner dropdown">
-  <%= button_to "Lougout", logout_path, class: "btn btn-lg btn-secondary", method: :get %>
+  <%= button_to "Logout", logout_path, class: "btn btn-lg btn-secondary", method: :get %>
 </div>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "kernel-builder",
   "private": true,
   "dependencies": {
+    "@popperjs/core": "^2.10.1",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,11 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@popperjs/core@^2.10.1":
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.1.tgz#728ecd95ab207aab8a9a4e421f0422db329232be"
+  integrity sha512-HnUhk1Sy9IuKrxEMdIRCxpIqPw6BFsbYSEUO9p/hNw5sMld/+3OLMWQP80F8/db9qsv3qUjs7ZR5bS/R+iinXw==
+
 "@rails/actioncable@^6.0.0":
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.1.4.tgz#c3c5a9f8302c429af9722b6c50ab48049016d2a3"


### PR DESCRIPTION
### Utilize Bootstrap to make app less ugly:

This PR revamps the look of the app by utilizing Twitter Bootstrap. All buttons are given styles and particular looks depending on their function. The root path now shows the `kernel_build#index` in the form of a new `kernel_table` partial. This makes it easier to see what `kernel_builds` the `current_user` has on the root page. Some routes were changes for "Back"/"Home" buttons to always route to the `root_path`. Also, some partials were created to help clean up the code a bit in areas where code is re-used in multiple places.

- Create new partials for renders that happen on multiple pages
  - `kernel_table`: uses Bootstraps's table content to render useful data for each `kernel_build` for the `current_user`
  - `logout_button`: uses css to render a Bootstrap button at the top right of the screen
  - `kernel_info`: shows useful info on a particular `@kernel_build`. Basically the `kernel_build#show`
  - `edit_form`: (WIP) -- Will most likely need a separate form partial to handle editing a specific `kernel_build`

![Capture](https://user-images.githubusercontent.com/74803363/134977480-fac8286a-3a34-47a5-88a3-ccd77fa72468.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/134977524-ae224030-2b4b-4d16-b29d-390d36e7e984.PNG)
![Capture](https://user-images.githubusercontent.com/74803363/134977577-43e202a2-a287-4ee0-ac2b-ec2fa9763588.PNG)
